### PR TITLE
Alternative get/set user value implementation

### DIFF
--- a/c-api/compat-5.2.c
+++ b/c-api/compat-5.2.c
@@ -3,6 +3,8 @@
 #define COMPAT_5_2_C
 #include "compat-5.2.h"
 
+#define COMPAT_5_2_KEY "_COMPAT52_NIL"
+
 #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM == 501
 
 int lua_absindex (lua_State *L, int i) {

--- a/c-api/compat-5.2.c
+++ b/c-api/compat-5.2.c
@@ -1,5 +1,6 @@
 #include "lua.h"
 #include "lauxlib.h"
+#define COMPAT_5_2_C
 #include "compat-5.2.h"
 
 #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM == 501
@@ -84,7 +85,7 @@ void lua_getuservalue (lua_State *L, int i) {
 	if (!lua_next(L, -2)) { /* The table is empty - might be the marker */
 		lua_pushlightuserdata(L, (void*)lua_setuservalue);
 		lua_rawget(L, LUA_REGISTRYINDEX);
-		if (lua_equal(L, -1, -2)) { /* It is the marker - return nil */
+		if (lua_rawequal(L, -1, -2)) { /* It is the marker - return nil */
 			lua_pop(L, 2);
 			lua_pushnil(L);
 		} else { /* Not the marker - return the actual empty table */
@@ -117,6 +118,13 @@ void lua_setuservalue (lua_State *L, int i) {
   lua_setfenv(L, i); /* Supplied table or marker empty table */
 }
 
+void* newuserdatax (lua_State *L, size_t sz) {
+	void* r = lua_newuserdata(L, sz);
+	luaL_checkstack(L, 1, "not enough stack slots");
+	lua_pushnil(L);
+	lua_setuservalue(L, -2);
+	return r;
+}
 
 /*
 ** Adapted from Lua 5.2.0

--- a/c-api/compat-5.2.c
+++ b/c-api/compat-5.2.c
@@ -83,7 +83,7 @@ void lua_getuservalue (lua_State *L, int i) {
   if (lua_istable(L, -1)) {
 	lua_pushnil(L);
 	if (!lua_next(L, -2)) { /* The table is empty - might be the marker */
-		lua_pushstring(L, COMPAT_5_2_KEY);
+		lua_pushliteral(L, COMPAT_5_2_KEY);
 		lua_rawget(L, LUA_REGISTRYINDEX);
 		if (lua_rawequal(L, -1, -2)) { /* It is the marker - return nil */
 			lua_pop(L, 2);
@@ -104,13 +104,13 @@ void lua_setuservalue (lua_State *L, int i) {
   luaL_checktype(L, i, LUA_TUSERDATA);
   if (lua_isnil(L, -1)) { /* Fetch marker empty table from registry */
 	lua_pop(L,1);
-	lua_pushstring(L, COMPAT_5_2_KEY);
+	lua_pushliteral(L, COMPAT_5_2_KEY);
 	lua_rawget(L, LUA_REGISTRYINDEX);
 	if (!lua_istable(L, -1)) { /* Create marker empty table if missing */
 		lua_pop(L, 1);
 		luaL_checkstack(L, 2, "not enough stack slots");
 		lua_createtable(L,0,0);
-		lua_pushstring(L, COMPAT_5_2_KEY);
+		lua_pushliteral(L, COMPAT_5_2_KEY);
 		lua_pushvalue(L,-2);
 		lua_rawset(L, LUA_REGISTRYINDEX);
 	}

--- a/c-api/compat-5.2.c
+++ b/c-api/compat-5.2.c
@@ -83,7 +83,7 @@ void lua_getuservalue (lua_State *L, int i) {
   if (lua_istable(L, -1)) {
 	lua_pushnil(L);
 	if (!lua_next(L, -2)) { /* The table is empty - might be the marker */
-		lua_pushlightuserdata(L, (void*)lua_setuservalue);
+		lua_pushstring(L, COMPAT_5_2_KEY);
 		lua_rawget(L, LUA_REGISTRYINDEX);
 		if (lua_rawequal(L, -1, -2)) { /* It is the marker - return nil */
 			lua_pop(L, 2);
@@ -104,13 +104,13 @@ void lua_setuservalue (lua_State *L, int i) {
   luaL_checktype(L, i, LUA_TUSERDATA);
   if (lua_isnil(L, -1)) { /* Fetch marker empty table from registry */
 	lua_pop(L,1);
-	lua_pushlightuserdata(L, (void*)lua_setuservalue);
+	lua_pushstring(L, COMPAT_5_2_KEY);
 	lua_rawget(L, LUA_REGISTRYINDEX);
 	if (!lua_istable(L, -1)) { /* Create marker empty table if missing */
 		lua_pop(L, 1);
 		luaL_checkstack(L, 2, "not enough stack slots");
 		lua_createtable(L,0,0);
-		lua_pushlightuserdata(L, (void*)lua_setuservalue);
+		lua_pushstring(L, COMPAT_5_2_KEY);
 		lua_pushvalue(L,-2);
 		lua_rawset(L, LUA_REGISTRYINDEX);
 	}

--- a/c-api/compat-5.2.h
+++ b/c-api/compat-5.2.h
@@ -42,7 +42,9 @@ lua_Unsigned luaL_optunsigned (lua_State *L, int i, lua_Unsigned def);
 #define luaL_newlib(L, l) \
   (lua_newtable((L)),luaL_setfuncs((L), (l), 0))
 
-#define lua_newuserdata(L, s) lua_newuserdata(L, s);lua_pushnil(L);lua_setuservalue(L,-2);
+#if !defined(COMPAT_5_2_C)
+#define lua_newuserdata(L, s) newuserdatax(L, s)
+#endif
 
 #endif /* Lua 5.0 *or* 5.1 */
 
@@ -57,4 +59,4 @@ void lua_getuservalue (lua_State *L, int i);
 void lua_setuservalue (lua_State *L, int i);
 void luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup);
 void luaL_setmetatable (lua_State *L, const char *tname);
-
+void* newuserdatax (lua_State *L, size_t sz);

--- a/c-api/compat-5.2.h
+++ b/c-api/compat-5.2.h
@@ -42,6 +42,8 @@ lua_Unsigned luaL_optunsigned (lua_State *L, int i, lua_Unsigned def);
 #define luaL_newlib(L, l) \
   (lua_newtable((L)),luaL_setfuncs((L), (l), 0))
 
+#define lua_newuserdata(L, s) lua_newuserdata(L, s);lua_pushnil(L);lua_setuservalue(L,-2);
+
 #endif /* Lua 5.0 *or* 5.1 */
 
 int lua_absindex (lua_State *L, int i);

--- a/c-api/compat-5.2.h
+++ b/c-api/compat-5.2.h
@@ -46,6 +46,8 @@ lua_Unsigned luaL_optunsigned (lua_State *L, int i, lua_Unsigned def);
 #define lua_newuserdata(L, s) newuserdatax(L, s)
 #endif
 
+#define COMPAT_5_2_KEY "COMPAT_5_2_KEY"
+
 #endif /* Lua 5.0 *or* 5.1 */
 
 int lua_absindex (lua_State *L, int i);

--- a/c-api/compat-5.2.h
+++ b/c-api/compat-5.2.h
@@ -46,8 +46,6 @@ lua_Unsigned luaL_optunsigned (lua_State *L, int i, lua_Unsigned def);
 #define lua_newuserdata(L, s) newuserdatax(L, s)
 #endif
 
-#define COMPAT_5_2_KEY "COMPAT_5_2_KEY"
-
 #endif /* Lua 5.0 *or* 5.1 */
 
 int lua_absindex (lua_State *L, int i);


### PR DESCRIPTION
How about this guys?

The idea is to use a specific empty table, stored in the registry under a light userdata key for guaranteed uniqueness, as the marker for 'nil' value. This allows `lua_setuservalue` and `lua_getuservalue` to handle `nil` correctly and is pretty efficient since the registry only needs to be consulted when `lua_getfenv` returns an empty table.

I also overlay `lua_newuserdata` using a macro so it does `lua_setuservalue` to `nil` after creating the userdata with the standard environment table, mimicking the 5.2 behavior automatically. Not sure if all compilers will handle this potentially recursive macro correctly though - it works fine in VS2010.
