### PR TITLE
Update lbitlib.c to Lua 5.2.3

### DIFF
--- a/lbitlib.c
+++ b/lbitlib.c
@@ -1,5 +1,5 @@
 /*
-** $Id: lbitlib.c,v 1.18 2013/03/19 13:19:12 roberto Exp $
+** $Id: lbitlib.c,v 1.18.1.2 2013/07/09 18:01:41 roberto Exp $
 ** Standard library for bitwise operations
 ** See Copyright Notice in lua.h
 */
@@ -135,7 +135,8 @@ static int b_rot (lua_State *L, int i) {
   b_uint r = luaL_checkunsigned(L, 1);
   i &= (LUA_NBITS - 1);  /* i = i % NBITS */
   r = trim(r);
-  r = (r << i) | (r >> (LUA_NBITS - i));
+  if (i != 0)  /* avoid undefined shift of LUA_NBITS when i == 0 */
+    r = (r << i) | (r >> (LUA_NBITS - i));
   lua_pushunsigned(L, trim(r));
   return 1;
 }

--- a/rockspecs/bit32-5.2.3-1.rockspec
+++ b/rockspecs/bit32-5.2.3-1.rockspec
@@ -1,0 +1,32 @@
+package = "bit32"
+
+version = "5.2.3-1"
+
+source = {
+   url = "git://github.com/hishamhm/lua-compat-5.2.git",
+   branch = "5.2.3",
+}
+
+description = {
+   summary = "Lua 5.2 bit manipulation library",
+   detailed = [[
+      bit32 is the native Lua 5.2 bit manipulation library,
+      backported to Lua 5.1
+   ]],
+   license = "MIT/X11",
+   homepage = "http://www.lua.org/manual/5.2/manual.html#6.7",
+}
+
+dependencies = {
+   "lua >= 5.1, < 5.2"
+}
+
+build = {
+   type = "builtin",
+   modules = {
+      bit32 = {
+         sources = { "lbitlib.c", "c-api/compat-5.2.c" },
+         incdirs = { "c-api" },
+      }
+   }
+}


### PR DESCRIPTION
This contains a small fix to avoid undefined behavior.

Update the rockspec from the scm-1 rockspec to make building work with
the current source arrangements.

This update also allows the bit32 rock to build with LuaJIT.