### PR TITLE
Allow bit32 to be built on Lua 5.[123]

### DIFF
--- a/rockspecs/bit32-5.2.3-2.rockspec
+++ b/rockspecs/bit32-5.2.3-2.rockspec
@@ -1,10 +1,10 @@
 package = "bit32"
 
-version = "scm-1"
+version = "5.2.3-2"
 
 source = {
    url = "git://github.com/hishamhm/lua-compat-5.2.git",
-   branch = "master",
+   tag = "bitlib-5.2.3",
 }
 
 description = {


### PR DESCRIPTION
It works on all of those; although Lua 5.2 & 5.3 normally come with `bit32`, it can now be automatically installed where it is lacking (when the user configures luarocks to say that `bit32` is not built in).